### PR TITLE
MiST: add direct SD Card upload feature

### DIFF
--- a/hdl/mist/data_io.v
+++ b/hdl/mist/data_io.v
@@ -1,12 +1,10 @@
 //
 // data_io.v
 //
-// io controller writable ram for the MiST board
+// data_io for the MiST board
 // http://code.google.com/p/mist-board/
 //
-// ZX Spectrum adapted version
-//
-// Copyright (c) 2015 Till Harbaum <till@harbaum.org>
+// Copyright (c) 2014 Till Harbaum <till@harbaum.org>
 //
 // This source file is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published
@@ -21,111 +19,161 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
+///////////////////////////////////////////////////////////////////////
 
-module data_io(
-    // io controller spi interface
-    input         sck,
-    input         ss,
-    input         sdi,
+module data_io
+(
+	input             clk_sys,
+	input             SPI_SCK,
+	input             SPI_SS2,
+	input             SPI_SS4,
+	input             SPI_DI,
+	input             SPI_DO, // yes, SPI_DO is input when SS4 active
 
-    output reg [4:0]  index,     // menu index used to upload the file
+	input             clkref_n, // assert ioctl_wr one cycle after clkref stobe (negative active)
 
-    // external ram interface
-    input               rst,
-    input               clk_sdram,
-    output reg          downloading_sdram,   // signal indicating an active download
-    output reg   [22:0] ioctl_addr,
-    output reg   [ 7:0] ioctl_data,
-    output reg          ioctl_wr
+	// ARM -> FPGA download
+	output reg        ioctl_download = 0, // signal indicating an active download
+	output reg  [7:0] ioctl_index,        // menu index used to upload the file
+	output reg        ioctl_wr,           // strobe indicating ioctl_dout valid
+	output reg [24:0] ioctl_addr,
+	output reg  [7:0] ioctl_dout
 );
 
-// *********************************************************************************
-// spi client
-// *********************************************************************************
+parameter START_ADDR = 25'd0;
+parameter ROM_DIRECT_UPLOAD = 0;
 
-// this core supports only the display related OSD commands
-// of the minimig
-reg [6:0]      sbuf;
-reg [7:0]      cmd;
-reg [4:0]      cnt=5'd0;
-reg rclk=1'b0;
-reg [7:0]       data;
+///////////////////////////////   DOWNLOADING   ///////////////////////////////
 
-localparam UIO_FILE_TX      = 8'h53;
-localparam UIO_FILE_TX_DAT  = 8'h54;
-localparam UIO_FILE_INDEX   = 8'h55;
+reg  [7:0] data_w;
+reg  [7:0] data_w2  = 0;
+reg        rclk   = 0;
+reg        rclk2  = 0;
+reg        addr_reset = 0;
 
-reg downloading_reg = 1'b0;
+reg        downloading_reg = 0;
+reg  [7:0] index_reg = 0;
+
+localparam DIO_FILE_TX      = 8'h53;
+localparam DIO_FILE_TX_DAT  = 8'h54;
+localparam DIO_FILE_INDEX   = 8'h55;
 
 // data_io has its own SPI interface to the io controller
-always@(posedge sck, posedge ss) begin
-    if(ss == 1'b1) begin
-        cnt <= 5'd0;
-    end
-    else begin
-        rclk <= 1'b0;
+always@(posedge SPI_SCK, posedge SPI_SS2) begin
+	reg  [6:0] sbuf;
+	reg  [7:0] cmd;
+	reg  [3:0] cnt;
+	reg [24:0] addr;
 
-        // don't shift in last bit. It is evaluated directly
-        // when writing to ram
-        if(cnt != 15)
-            sbuf <= { sbuf[5:0], sdi};
+	if(SPI_SS2) cnt <= 0;
+	else begin
+		// don't shift in last bit. It is evaluated directly
+		// when writing to ram
+		if(cnt != 15) sbuf <= { sbuf[5:0], SPI_DI};
 
-        // count 0-7 8-15 8-15 ...
-        if(cnt < 15)
-            cnt <= cnt + 4'd1;
-        else
-            cnt <= 4'd8;
+		// count 0-7 8-15 8-15 ...
+		if(cnt != 15) cnt <= cnt + 1'd1;
+			else cnt <= 8;
 
-        // finished command byte
-        if(cnt == 7)
-            cmd <= {sbuf, sdi};
+		// finished command byte
+		if(cnt == 7) cmd <= {sbuf, SPI_DI};
 
-        // prepare/end transmission
-        if((cmd == UIO_FILE_TX) && (cnt == 15)) begin
-            // prepare
-            if(sdi) begin
-                // addr <= 25'd0;
-                downloading_reg <= 1'b1;
-            end else
-                downloading_reg <= 1'b0;
-        end
+		// prepare/end transmission
+		if((cmd == DIO_FILE_TX) && (cnt == 15)) begin
+			// prepare
+			if(SPI_DI) begin
+				addr_reset <= ~addr_reset;
+				downloading_reg <= 1;
+			end else begin
+				downloading_reg <= 0;
+			end
+		end
 
-        // command 0x54: UIO_FILE_TX
-        if((cmd == UIO_FILE_TX_DAT) && (cnt == 15)) begin
-            data <= {sbuf, sdi};
-            rclk <= 1'b1;
-        end
+		// command 0x54: UIO_FILE_TX
+		if((cmd == DIO_FILE_TX_DAT) && (cnt == 15)) begin
+			data_w <= {sbuf, SPI_DI};
+			rclk <= ~rclk;
+		end
 
-      // expose file (menu) index
-      if((cmd == UIO_FILE_INDEX) && (cnt == 15))
-            index <= {sbuf[3:0], sdi};
-    end
+		// expose file (menu) index
+		if((cmd == DIO_FILE_INDEX) && (cnt == 15)) index_reg <= {sbuf, SPI_DI};
+	end
 end
 
-reg rclkD, rclkD2;
-reg sync_aux;
 
-always@(posedge clk_sdram or posedge rst)
-    if( rst ) begin
-        ioctl_addr <= ~23'd0;
-        ioctl_wr   <= 1'b0;
-        ioctl_data <= 8'h0;
-    end else begin
-        { downloading_sdram, sync_aux } <= { sync_aux, downloading_reg };
-        if ({ downloading_sdram, sync_aux } == 2'b01) begin
-            ioctl_addr <= ~23'd0;
-            ioctl_wr   <= 1'b0;
-        end
+// direct SD Card->FPGA transfer
+generate if (ROM_DIRECT_UPLOAD == 1) begin
 
-        // bring rclk from spi clock domain into sdram clock domain
-        rclkD <= rclk;
-        rclkD2 <= rclkD;
+always@(posedge SPI_SCK, posedge SPI_SS4) begin
+	reg  [6:0] sbuf2;
+	reg  [2:0] cnt2;
+	reg  [9:0] bytecnt;
 
-        if( rclkD && !rclkD2 ) begin
-            ioctl_data <= data;
-            ioctl_addr <= ioctl_addr + 1'd1;
-        end
-        ioctl_wr <= rclkD && !rclkD2;
-    end
+	if(SPI_SS4) begin
+		cnt2 <= 0;
+		bytecnt <= 0;
+	end else begin
+		// don't shift in last bit. It is evaluated directly
+		// when writing to ram
+		if(cnt2 != 7)
+			sbuf2 <= { sbuf2[5:0], SPI_DO };
+
+		cnt2 <= cnt2 + 1'd1;
+
+		// received a byte
+		if(cnt2 == 7) begin
+			bytecnt <= bytecnt + 1'd1;
+			// read 514 byte/sector (512 + 2 CRC)
+			if (bytecnt == 513) bytecnt <= 0;
+			// don't send the CRC bytes
+			if (~bytecnt[9]) begin
+				data_w2 <= {sbuf2, SPI_DO};
+				rclk2 <= ~rclk2;
+			end
+		end
+	end
+end
+
+end
+endgenerate
+
+always@(posedge clk_sys) begin
+	// bring flags from spi clock domain into core clock domain
+	reg rclkD, rclkD2;
+	reg rclk2D, rclk2D2;
+	reg addr_resetD, addr_resetD2;
+	reg wr_int, wr_int_direct;
+	reg [24:0] addr;
+
+	{ rclkD, rclkD2 } <= { rclk, rclkD };
+	{ rclk2D ,rclk2D2 } <= { rclk2, rclk2D };
+	{ addr_resetD, addr_resetD2 } <= { addr_reset, addr_resetD };
+
+	ioctl_wr <= 0;
+
+	if (!downloading_reg) ioctl_download <= 0;
+
+	if (~clkref_n) begin
+		wr_int <= 0;
+		wr_int_direct <= 0;
+		if (wr_int || wr_int_direct) begin
+			ioctl_dout <= wr_int ? data_w : data_w2;
+			ioctl_wr <= 1;
+			addr <= addr + 1'd1;
+			ioctl_addr <= addr;
+		end
+	end
+
+	// detect transfer start from the SPI receiver
+	if(addr_resetD ^ addr_resetD2) begin
+		addr <= START_ADDR;
+		ioctl_index <= index_reg;
+		ioctl_download <= 1;
+	end
+
+	// detect new byte from the SPI receiver
+	if (rclkD ^ rclkD2)   wr_int <= 1;
+	if (rclk2D ^ rclk2D2) wr_int_direct <= 1;
+end
 
 endmodule

--- a/hdl/mist/jtframe_mist_base.v
+++ b/hdl/mist/jtframe_mist_base.v
@@ -55,7 +55,7 @@ module jtframe_mist_base #(parameter
     output          VIDEO_HS,
     output          VIDEO_VS,
     // SPI interface to arm io controller
-    output          SPI_DO,
+    inout           SPI_DO,
     input           SPI_DI,
     input           SPI_SCK,
     input           SPI_SS2,
@@ -125,7 +125,7 @@ assign snd_pwm_right = 1'b0;
 `endif
 
 `ifndef SIMULATION
-user_io #(.STRLEN(CONF_STR_LEN)) u_userio(
+user_io #(.STRLEN(CONF_STR_LEN), .ROM_DIRECT_UPLOAD(1'b1)) u_userio(
     .clk_sys        ( clk_sys   ),
     .conf_str       ( CONF_STR  ),
     .SPI_CLK        ( SPI_SCK   ),
@@ -167,18 +167,19 @@ assign scan2x_enb = `SCANDOUBLER_DISABLE;
 assign ypbpr = 1'b0;
 `endif
 
-data_io u_datain (
-    .sck                ( SPI_SCK      ),
-    .ss                 ( SPI_SS2      ),
-    .sdi                ( SPI_DI       ),
+data_io #(.ROM_DIRECT_UPLOAD(1'b1)) u_datain (
+    .SPI_SCK            ( SPI_SCK      ),
+    .SPI_SS2            ( SPI_SS2      ),
+    .SPI_SS4            ( SPI_SS4      ),
+    .SPI_DI             ( SPI_DI       ),
+    .SPI_DO             ( SPI_DO       ),
     
-    .rst                ( rst          ),
-    .clk_sdram          ( clk_rom      ),
-    .downloading_sdram  ( downloading  ),
+    .clk_sys            ( clk_rom      ),
+    .ioctl_download     ( downloading  ),
     .ioctl_addr         ( ioctl_addr   ),
-    .ioctl_data         ( ioctl_data   ),
+    .ioctl_dout         ( ioctl_data   ),
     .ioctl_wr           ( ioctl_wr     ),
-    .index              ( /* unused*/  )
+    .ioctl_index        ( /* unused*/  )
 );
 
 // OSD will only get simulated if SIMULATE_OSD is defined

--- a/hdl/mist/jtframe_mist_top.sv
+++ b/hdl/mist/jtframe_mist_top.sv
@@ -44,7 +44,7 @@ module `MISTTOP(
     output          SDRAM_CLK,      // SDRAM Clock
     output          SDRAM_CKE,      // SDRAM Clock Enable
    // SPI interface to arm io controller
-    output          SPI_DO,
+    inout           SPI_DO,
     input           SPI_DI,
     input           SPI_SCK,
     input           SPI_SS2,

--- a/hdl/mist/user_io.v
+++ b/hdl/mist/user_io.v
@@ -22,8 +22,10 @@
 
 // parameter STRLEN and the actual length of conf_str have to match
 
-module user_io #(parameter STRLEN=0, parameter PS2DIV=100) (
+module user_io #(parameter STRLEN=0, parameter PS2DIV=100, parameter ROM_DIRECT_UPLOAD=0) (
 	input [(8*STRLEN)-1:0] conf_str,
+	output       [9:0]  conf_addr, // RAM address for config string, if STRLEN=0
+	input        [7:0]  conf_chr,
 
 	input               clk_sys, // clock for system-related messages (kbd, joy, etc...)
 	input               clk_sd,  // clock for SD-card related messages
@@ -33,41 +35,55 @@ module user_io #(parameter STRLEN=0, parameter PS2DIV=100) (
 	output reg          SPI_MISO,
 	input               SPI_MOSI,
 
-	output reg [31:0]   joystick_0,
-	output reg [31:0]   joystick_1,
-	output reg [31:0]   joystick_2,
-	output reg [31:0]   joystick_3,
-	output reg [31:0]   joystick_4,
-	output reg [15:0]   joystick_analog_0,
-	output reg [15:0]   joystick_analog_1,
-	output [1:0]        buttons,
-	output [1:0]        switches,
-	output 		        scandoubler_disable,
+	output reg   [31:0] joystick_0,
+	output reg   [31:0] joystick_1,
+	output reg   [31:0] joystick_2,
+	output reg   [31:0] joystick_3,
+	output reg   [31:0] joystick_4,
+	output reg   [15:0] joystick_analog_0,
+	output reg   [15:0] joystick_analog_1,
+	output        [1:0] buttons,
+	output        [1:0] switches,
+	output              scandoubler_disable,
 	output              ypbpr,
-	output reg [31:0]   status,
+	output              no_csync,
+	output reg   [31:0] status,
+	output reg    [6:0] core_mod, // core variant, sent before the config string is requested
 
 	// connection to sd card emulation
 	input        [31:0] sd_lba,
-	input 		        sd_rd,
-	input 		        sd_wr,
-	output reg 	        sd_ack,
+	input               sd_rd,
+	input               sd_wr,
+	output reg          sd_ack,
 	output reg          sd_ack_conf,
-	input 		        sd_conf,
-	input 		        sd_sdhc,
+	input               sd_conf,
+	input               sd_sdhc,
 	output reg    [7:0] sd_dout, // valid on rising edge of sd_dout_strobe
-	output reg 	        sd_dout_strobe,
+	output reg          sd_dout_strobe,
 	input         [7:0] sd_din,
-	output reg 	        sd_din_strobe,
+	output reg          sd_din_strobe,
 	output reg    [8:0] sd_buff_addr,
 
 	output reg          img_mounted, //rising edge if a new image is mounted
 	output reg   [31:0] img_size,    // size of image in bytes
 
-	// ps2 keyboard emulation
+	// ps2 keyboard/mouse emulation
 	output              ps2_kbd_clk,
 	output reg          ps2_kbd_data,
 	output              ps2_mouse_clk,
 	output reg          ps2_mouse_data,
+
+	// keyboard data
+	output reg          key_pressed,  // 1-make (pressed), 0-break (released)
+	output reg          key_extended, // extended code
+	output reg    [7:0] key_code,     // key scan code
+	output reg          key_strobe,   // key data valid
+
+	// mouse data
+	output reg    [8:0] mouse_x,
+	output reg    [8:0] mouse_y,
+	output reg    [7:0] mouse_flags,  // YOvfl, XOvfl, dy8, dx8, 1, mbtn, rbtn, lbtn
+	output reg          mouse_strobe, // mouse data is valid on mouse_strobe
 
 	// serial com port
 	input [7:0]         serial_data,
@@ -76,18 +92,22 @@ module user_io #(parameter STRLEN=0, parameter PS2DIV=100) (
 
 reg [6:0]     sbuf;
 reg [7:0]     cmd;
-reg [2:0] 	  bit_cnt;    // counts bits 0-7 0-7 ...
+reg [2:0]     bit_cnt;    // counts bits 0-7 0-7 ...
 reg [9:0]     byte_cnt;   // counts bytes
-reg [7:0] 	  but_sw;
+reg [7:0]     but_sw;
 reg [2:0]     stick_idx;
 
 assign buttons = but_sw[1:0];
 assign switches = but_sw[3:2];
 assign scandoubler_disable = but_sw[4];
 assign ypbpr = but_sw[5];
+assign no_csync = but_sw[6];
+
+assign conf_addr = byte_cnt;
 
 // this variant of user_io is for 8 bit cores (type == a4) only
-wire [7:0] core_type = 8'ha4;
+// bit 4 indicates ROM direct upload capability
+wire [7:0] core_type = ROM_DIRECT_UPLOAD ? 8'hb4 : 8'ha4;
 
 // command byte read by the io controller
 wire [7:0] sd_cmd = { 4'h5, sd_conf, sd_sdhc, sd_wr, sd_rd };
@@ -300,7 +320,7 @@ reg [7:0] spi_byte_out;
 
 always@(negedge spi_sck or posedge SPI_SS_IO) begin
 	if(SPI_SS_IO == 1) begin
-	   SPI_MISO <= 1'bZ;
+		SPI_MISO <= 1'bZ;
 	end else begin
 		SPI_MISO <= spi_byte_out[~bit_cnt];
 	end
@@ -319,7 +339,8 @@ always@(posedge spi_sck or posedge SPI_SS_IO) begin
 			spi_byte_out <= 0;
 			case({(!byte_cnt) ? {sbuf, SPI_MOSI} : cmd})
 			// reading config string
-			8'h14: if(byte_cnt < STRLEN) spi_byte_out <= conf_str[(STRLEN - byte_cnt - 1)<<3 +:8];
+			8'h14: if (STRLEN == 0) spi_byte_out <= conf_chr; else
+			       if(byte_cnt < STRLEN) spi_byte_out <= conf_str[(STRLEN - byte_cnt - 1)<<3 +:8];
 
 			// reading sd card status
 			8'h16: if(byte_cnt == 0) begin
@@ -374,11 +395,20 @@ always @(posedge clk_sys) begin
 	reg [7:0] acmd;
 	reg [7:0] abyte_cnt;   // counts bytes
 
+	reg [7:0] mouse_flags_r;
+	reg [7:0] mouse_x_r;
+
+	reg       key_pressed_r;
+	reg       key_extended_r;
+
 	//synchronize between SPI and sys clock domains
 	spi_receiver_strobeD <= spi_receiver_strobe_r;
 	spi_receiver_strobe <= spi_receiver_strobeD;
 	spi_transfer_endD	<= spi_transfer_end_r;
 	spi_transfer_end	<= spi_transfer_endD;
+
+	key_strobe <= 0;
+	mouse_strobe <= 0;
 
 	if (~spi_transfer_endD & spi_transfer_end) begin
 		abyte_cnt <= 8'd0;
@@ -402,11 +432,32 @@ always @(posedge clk_sys) begin
 					// store incoming ps2 mouse bytes
 					ps2_mouse_fifo[ps2_mouse_wptr] <= spi_byte_in;
 					ps2_mouse_wptr <= ps2_mouse_wptr + 1'd1;
+					if (abyte_cnt == 1) mouse_flags_r <= spi_byte_in;
+					else if (abyte_cnt == 2) mouse_x_r <= spi_byte_in;
+					else if (abyte_cnt == 3) begin
+						// flags: YOvfl, XOvfl, dy8, dx8, 1, mbtn, rbtn, lbtn
+						mouse_flags <= mouse_flags_r;
+						mouse_x <= { mouse_flags_r[4], mouse_x_r };
+						mouse_y <= { mouse_flags_r[5], spi_byte_in };
+						mouse_strobe <= 1;
+					end
 				end
 				8'h05: begin
 					// store incoming ps2 keyboard bytes
 					ps2_kbd_fifo[ps2_kbd_wptr] <= spi_byte_in;
 					ps2_kbd_wptr <= ps2_kbd_wptr + 1'd1;
+					if (abyte_cnt == 1) begin
+						key_extended_r <= 0;
+						key_pressed_r <= 1;
+					end
+					if (spi_byte_in == 8'he0) key_extended_r <= 1'b1;
+					else if (spi_byte_in == 8'hf0) key_pressed_r <= 1'b0;
+					else begin
+						key_extended <= key_extended_r;
+						key_pressed <= key_pressed_r || abyte_cnt == 1;
+						key_code <= spi_byte_in;
+						key_strobe <= 1'b1;
+					end
 				end
 
 				// joystick analog
@@ -434,7 +485,10 @@ always @(posedge clk_sys) begin
 				// status, 32bit version
 				8'h1e: if(abyte_cnt<5) status[(abyte_cnt-1)<<3 +:8] <= spi_byte_in;
 
-				endcase
+				// core variant
+				8'h21: core_mod <= spi_byte_in[6:0];
+
+			endcase
 		end
 	end
 end
@@ -506,8 +560,10 @@ always @(posedge clk_sd) begin
 
 				// send sector FPGA -> IO
 				8'h18: begin
-					sd_din_strobe <= 1'b1;
-					if(~&sd_buff_addr) sd_buff_addr <= sd_buff_addr + 1'b1;
+					if(~&sd_buff_addr) begin
+						sd_din_strobe <= 1'b1;
+						sd_buff_addr <= sd_buff_addr + 1'b1;
+					end
 				end
 
 				// send SD config IO -> FPGA


### PR DESCRIPTION
On the MiST hardware, the SD Card is directly connected to the FPGA,
thus it's possible to bypass the ARM MCU.
ROM loading will be about 4 times faster.