### PR TITLE
Update MiST direct ROM download

### DIFF
--- a/hdl/mist/data_io.v
+++ b/hdl/mist/data_io.v
@@ -34,10 +34,12 @@ module data_io
 
 	// ARM -> FPGA download
 	output reg        ioctl_download = 0, // signal indicating an active download
-	output reg  [7:0] ioctl_index,        // menu index used to upload the file
+	output reg  [7:0] ioctl_index,        // menu index used to upload the file ([7:6] - extension index, [5:0] - menu index)
 	output reg        ioctl_wr,           // strobe indicating ioctl_dout valid
 	output reg [24:0] ioctl_addr,
-	output reg  [7:0] ioctl_dout
+	output reg  [7:0] ioctl_dout,
+	output reg [23:0] ioctl_fileext,      // file extension
+	output reg [31:0] ioctl_filesize      // file size
 );
 
 parameter START_ADDR = 25'd0;
@@ -50,23 +52,27 @@ reg  [7:0] data_w2  = 0;
 reg        rclk   = 0;
 reg        rclk2  = 0;
 reg        addr_reset = 0;
-
+reg [31:0] filesize;
 reg        downloading_reg = 0;
 reg  [7:0] index_reg = 0;
 
 localparam DIO_FILE_TX      = 8'h53;
 localparam DIO_FILE_TX_DAT  = 8'h54;
 localparam DIO_FILE_INDEX   = 8'h55;
+localparam DIO_FILE_INFO    = 8'h56;
 
 // data_io has its own SPI interface to the io controller
-always@(posedge SPI_SCK, posedge SPI_SS2) begin
+always@(posedge SPI_SCK, posedge SPI_SS2) begin : SPI_RECEIVER
 	reg  [6:0] sbuf;
 	reg  [7:0] cmd;
 	reg  [3:0] cnt;
+	reg  [5:0] bytecnt;
 	reg [24:0] addr;
 
-	if(SPI_SS2) cnt <= 0;
-	else begin
+	if(SPI_SS2) begin
+		bytecnt <= 0;
+		cnt <= 0;
+	end	else begin
 		// don't shift in last bit. It is evaluated directly
 		// when writing to ram
 		if(cnt != 15) sbuf <= { sbuf[5:0], SPI_DI};
@@ -97,21 +103,36 @@ always@(posedge SPI_SCK, posedge SPI_SS2) begin
 
 		// expose file (menu) index
 		if((cmd == DIO_FILE_INDEX) && (cnt == 15)) index_reg <= {sbuf, SPI_DI};
+
+		// receiving FAT directory entry (mist-firmware/fat.h - DIRENTRY)
+		if((cmd == DIO_FILE_INFO) && (cnt == 15)) begin
+			bytecnt <= bytecnt + 1'd1;
+			case (bytecnt)
+				8'h08: ioctl_fileext[23:16]  <= {sbuf, SPI_DI};
+				8'h09: ioctl_fileext[15: 8]  <= {sbuf, SPI_DI};
+				8'h0A: ioctl_fileext[ 7: 0]  <= {sbuf, SPI_DI};
+				8'h1C: ioctl_filesize[ 7: 0] <= {sbuf, SPI_DI};
+				8'h1D: ioctl_filesize[15: 8] <= {sbuf, SPI_DI};
+				8'h1E: ioctl_filesize[23:16] <= {sbuf, SPI_DI};
+				8'h1F: ioctl_filesize[31:24] <= {sbuf, SPI_DI};
+			endcase
+		end
 	end
 end
-
 
 // direct SD Card->FPGA transfer
 generate if (ROM_DIRECT_UPLOAD == 1) begin
 
-always@(posedge SPI_SCK, posedge SPI_SS4) begin
+always@(posedge SPI_SCK, posedge SPI_SS4) begin : SPI_DIRECT_RECEIVER
 	reg  [6:0] sbuf2;
 	reg  [2:0] cnt2;
 	reg  [9:0] bytecnt;
+	reg [31:0] filepos;
 
 	if(SPI_SS4) begin
 		cnt2 <= 0;
 		bytecnt <= 0;
+		filepos <= 0;
 	end else begin
 		// don't shift in last bit. It is evaluated directly
 		// when writing to ram
@@ -126,7 +147,8 @@ always@(posedge SPI_SCK, posedge SPI_SS4) begin
 			// read 514 byte/sector (512 + 2 CRC)
 			if (bytecnt == 513) bytecnt <= 0;
 			// don't send the CRC bytes
-			if (~bytecnt[9]) begin
+			if (~bytecnt[9] && filepos != ioctl_filesize) begin
+				filepos <= filepos + 1'd1;
 				data_w2 <= {sbuf2, SPI_DO};
 				rclk2 <= ~rclk2;
 			end
@@ -137,7 +159,7 @@ end
 end
 endgenerate
 
-always@(posedge clk_sys) begin
+always@(posedge clk_sys) begin : DATA_OUT
 	// bring flags from spi clock domain into core clock domain
 	reg rclkD, rclkD2;
 	reg rclk2D, rclk2D2;

--- a/hdl/mist/jtframe_mist.sv
+++ b/hdl/mist/jtframe_mist.sv
@@ -74,7 +74,7 @@ module jtframe_mist #(parameter
     input           sdram_rnw,
     input  [15:0]   data_write,
     // SPI interface to arm io controller
-    output          SPI_DO,
+    inout           SPI_DO,
     input           SPI_DI,
     input           SPI_SCK,
     input           SPI_SS2,

--- a/hdl/mist/jtframe_mist_base.v
+++ b/hdl/mist/jtframe_mist_base.v
@@ -125,7 +125,7 @@ assign snd_pwm_right = 1'b0;
 `endif
 
 `ifndef SIMULATION
-user_io #(.STRLEN(CONF_STR_LEN)/*, .ROM_DIRECT_UPLOAD(1'b1)*/) u_userio(
+user_io #(.STRLEN(CONF_STR_LEN), .ROM_DIRECT_UPLOAD(1'b1)) u_userio(
     .clk_sys        ( clk_sys   ),
     .conf_str       ( CONF_STR  ),
     .SPI_CLK        ( SPI_SCK   ),


### PR DESCRIPTION
This is the byte-exact direct file upload code for data_io. Turned out the firmware doesn't send the directory entry for the ROM, so I had to add it. Please upgrade to 200311:
https://github.com/mist-devel/mist-binaries/tree/master/firmware
