### PR TITLE
MiST: add force synchronous clear signals

### DIFF
--- a/hdl/mist/mist.qsf
+++ b/hdl/mist/mist.qsf
@@ -185,6 +185,7 @@ set_global_assignment -name CDF_FILE jtag.cdf
 # SDRAM
 set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to SDRAM_*
 set_instance_assignment -name FAST_OUTPUT_ENABLE_REGISTER ON -to SDRAM_DQ[*]
+set_global_assignment -name FORCE_SYNCH_CLEAR ON
 
 set_global_assignment -name QIP_FILE ${MODULES}/jtframe/hdl/mist/pll48/jtframe_pll0.qip
 set_global_assignment -name QIP_FILE ${MODULES}/jtframe/hdl/mist/pll48/jtframe_pll1.qip


### PR DESCRIPTION
Avoids the issue of:
Warning (176279): Can't pack register node "jtframe_mist:u_frame|jtframe_board:u_board|jtframe_sdram:u_sdram|SDRAM_A[1]" into I/O pin "SDRAM_A[1]". The node "jtframe_mist:u_frame|jtframe_board:u_board|jtframe_sdram:u_sdram|SDRAM_A[1]" cannot simultaneously use clear and load signals.